### PR TITLE
Use absolute path for repository Brewfile

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -154,7 +154,7 @@ update_homebrew() {
   echo "$FUNCNAME: Installing/updating some CocoaPod essentials:"
   script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
   cat "$script_dir"/Brewfile
-  brew bundle --verbose
+  brew bundle --file="$script_dir/Brewfile" --verbose
 
   if [[ -r "$HOME/.Brewfile" ]]; then
     echo "$FUNCNAME: Installing/upgrading formulae listed in $HOME/.Brewfile."


### PR DESCRIPTION
This fixes an issue where if you executed the script from outside of the cloned directory
the Brewfile would not be found and subsequent steps would fail since rbenv would't be installed.