### PR TITLE
Permissions change for 10.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
 language: bash
-sudo: required
+sudo: false
 dist: trusty
 
 cache:
-- apt
+  - apt
 
-before_install:
-    - echo "deb http://archive.ubuntu.com/ubuntu/ wily universe" | sudo tee -a /etc/apt/sources.list
-    - sudo apt-get update -q
-    - sudo apt-get install shellcheck -y
-    
+addons:
+  apt:
+    sources:
+    - debian-sid
+    packages:
+    - shellcheck
+
 script:
   # Run shellcheck with some diagnostic exclusions:
   #

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Operating System:
 * OS X Yosemite (10.10)
 * OS X El Capitan (10.11)
 * macOS Sierra (10.12) 
+* masOS High Sierra (10.13)
 
 Install
 -------

--- a/bootstrap
+++ b/bootstrap
@@ -88,7 +88,7 @@ announce_editing_shell_runconfig() {
 
 
 ensure_homebrew_prefix_usable() {
-  echo "$FUNCNAME: Your Homebrew prefix is ${HOMEBREW_PREFIX:-/usr/local}. Let's ensure it's usable by Homebrew (it exists as a directory, and you can write to it)."
+  echo "$FUNCNAME: Your Homebrew prefix is ${HOMEBREW_PREFIX:-/usr/local}. Let's ensure it's usable by Homebrew (it exists as a directory, and you have read access)."
   HOMEBREW_PREFIX="$(brew --prefix)"
   if [[ ! -e "$HOMEBREW_PREFIX" ]]; then
     HOMEBREW_PREFIX="/usr/local"
@@ -96,8 +96,8 @@ ensure_homebrew_prefix_usable() {
 
   current_group_name="$(id -ng)"
   if [[ -d "$HOMEBREW_PREFIX" ]]; then
-    # brew update requires that HOMEBREW_PREFIX be writeable.
-    if [[ ! -w "$HOMEBREW_PREFIX" ]]; then
+    # brew update requires that HOMEBREW_PREFIX be readable.
+    if [[ ! -r "$HOMEBREW_PREFIX" ]]; then
       # chown -R was taking a glacial age to run,
       # especially when the actual problem was the Google App Engine installer
       # had decided that /usr/local itself should be owned by root:wheel.


### PR DESCRIPTION
Brew needs write access to its sub directories but not necessarily the prefix directory itself.

For example on 10.13 /usr/local is not writable but ./Homebrew, ./Cellar etc are writable.

Since we're only requesting a group change on /usr/local it seems better to let brew output any writable errors rather than trying to make each subdirectory writable.