### PR TITLE
updates brew installer to use bash

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -131,8 +131,8 @@ ensure_homebrew_prefix_usable() {
 update_homebrew() {
   if ! command -v brew >/dev/null; then
     fancy_echo "$FUNCNAME: Installing Homebrew, a handy OS X package manager (see http://brew.sh)."
-      curl -fsS \
-        'https://raw.githubusercontent.com/Homebrew/install/master/install' | ruby
+
+      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
       append_to_shellrc '# recommended by brew doctor'
 


### PR DESCRIPTION
message from ruby installer:
Warning: The Ruby Homebrew installer is now deprecated and has been rewritten in
Bash. Please migrate...